### PR TITLE
Add ability to specify binary via command line args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,12 @@
 
 **.pyc
 
+# Environments
+[eE][nN][vV]*/
+.[eE][nN][vV]*/
+[vV][eE][nN][vV]*/
+.[vV][eE][nN][vV]*/
+
 #VSCode
 
 /.vscode/*

--- a/BOSSA_GUI/BOSSA_GUI/BOSSA_GUI.py
+++ b/BOSSA_GUI/BOSSA_GUI/BOSSA_GUI.py
@@ -11,8 +11,15 @@ Please see the LICENSE.md for more details
 # import action things - the .syntax is used since these are part of the package
 from .au_worker import AUxWorker
 from .au_action import AxJob
-from .au_act_samba_loader import AUxSAMBADetect, AUxSAMBAErase, AUxSAMBAProgram, AUxSAMBAVerify, AUxSAMBAReset
+from .au_act_samba_loader import (
+    AUxSAMBADetect,
+    AUxSAMBAErase,
+    AUxSAMBAProgram,
+    AUxSAMBAVerify,
+    AUxSAMBAReset,
+)
 
+import argparse
 import darkdetect
 import sys
 import os
@@ -25,13 +32,22 @@ import time
 
 from typing import Iterator, Tuple
 
-from PyQt5.QtCore import QSettings, QProcess, QTimer, Qt, QIODevice, pyqtSignal, pyqtSlot, QObject
-from PyQt5.QtWidgets import QWidget, QLabel, QComboBox, QGridLayout, \
-    QPushButton, QApplication, QLineEdit, QFileDialog, QPlainTextEdit, \
-    QAction, QActionGroup, QMenu, QMenuBar, QMainWindow, QMessageBox, \
-    QCheckBox
+from PyQt5.QtCore import QSettings, pyqtSignal, pyqtSlot
+from PyQt5.QtWidgets import (
+    QWidget,
+    QLabel,
+    QComboBox,
+    QGridLayout,
+    QPushButton,
+    QApplication,
+    QLineEdit,
+    QFileDialog,
+    QPlainTextEdit,
+    QMessageBox,
+    QCheckBox,
+)
 from PyQt5.QtGui import QCloseEvent, QTextCursor, QIcon, QFont
-from PyQt5.QtSerialPort import QSerialPortInfo, QSerialPortInfo
+from PyQt5.QtSerialPort import QSerialPortInfo
 
 _APP_NAME = "BOSSA GUI"
 
@@ -791,14 +807,37 @@ class MainWidget(QWidget):
 def startGUI():
     """Start the GUI"""
     from sys import exit as sysExit
+
+    # Parse command-line arguments
+    parser = argparse.ArgumentParser(description=f"{_APP_NAME} - {_APP_VERSION}")
+    parser.add_argument(
+        "-fw",
+        "--firmware",
+        type=str,
+        help="Path to the firmware binary file to upload.",
+    )
+    args, unknown = parser.parse_known_args()  # Ignore invalid arguments
+
     app = QApplication([])
     app.setOrganizationName('SparkFun Electronics')
     app.setApplicationName(_APP_NAME + ' - ' + _APP_VERSION)
     app.setWindowIcon(QIcon(resource_path("sfe_logo_sm.png")))
     app.setApplicationVersion(_APP_VERSION)
     w = MainWidget()
+
+    if unknown:
+        w.show_warning_message(f"Unrecognized arguments: {unknown}")
+
+    # Set the firmware path if provided via command-line
+    if args.firmware:
+        if os.path.exists(args.firmware):
+            w.firmwareLocation_lineedit.setText(args.firmware)
+        else:
+            w.show_error_message(f"File not found: {args.firmware}")
+
     w.show()
     sys.exit(app.exec_())
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     startGUI()

--- a/README.md
+++ b/README.md
@@ -168,6 +168,26 @@ Extract it. Python SAM-BA Loader is in the ```BOSSA_GUI\SAMBALoad``` sub-folder.
 * Add the ```--reset``` switch to reset the board when the operation is complete. E.g. ```python SAMBALoader.py -p COM1 --reset verify -a 0x2000 -f myCode.bin```
 * Add the ```-v``` switch to display helpful verbose messages. Add ```-vv``` for even more verbose messages.
 
+### Specifying Firmware via Command-Line Argument
+
+You can specify the firmware file for the BOSSA_GUI application via a command-line argument. This preloads the firmware file into the GUI, saving time.
+
+#### Usage
+
+* **Windows**:
+
+  ```.\BOSSA_GUI.exe --firmware "C:\path\to\firmware.bin"```
+
+* **Linux/macOS**:
+
+  ```./BOSSA_GUI --firmware "/path/to/firmware.bin"```
+
+* **Python (direct execution)**:
+
+  ```python BOSSA_GUI.py --firmware "/path/to/firmware.bin"```
+
+Ensure the specified firmware path is valid and points to a `.bin` file. If the file does not exist, an error message will be printed.
+
 ## Thanks
 
 Big thanks go to Dean Camera (@abcminiuser) and the contributors to [Python SAM-BA Loader](https://github.com/abcminiuser/sam-ba-loader).


### PR DESCRIPTION
Adds the ability to specify a firmware binary via command line arguments with argparse. This is done by running the application with `-fw` or `--firmware` followed by the path to the binary. This allows the application to be used in a manner where the binary file can be "preloaded".

In the event of unrecognized arguments, or a nonexistent file, an appropriate error message is shown.

Additionally, the README.md has been updated to reflect this change.